### PR TITLE
1285_동전뒤집기

### DIFF
--- a/YOUNGLIN/BOJ_1285_동전뒤집기.java
+++ b/YOUNGLIN/BOJ_1285_동전뒤집기.java
@@ -1,0 +1,48 @@
+package day2205.day09;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_1285_동전뒤집기 {
+
+    static int n, map[][];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        map = new int[n][n];
+
+        for (int i = 0; i < n; i++) {
+            char[] chars = br.readLine().toCharArray();
+            for (int j = 0; j < n; j++) {
+                if (chars[j] == 'H') map[i][j] = 0;
+                else map[i][j] = 1;
+            }
+        }
+        
+        int answer = n*n;
+
+        for (int bit = 0; bit < (1 << n); bit++) {
+            int sum = 0;
+            for (int i = 0; i < n; i++) {
+                int back = 0;
+                for (int j = 0; j < n; j++) {
+                    int cur = map[i][j];
+
+                    if ((bit & (1 << j)) != 0) {
+                        cur = (cur == 1 ? 0 : 1);
+                    }
+
+                    if (cur == 1) {
+                        back++;
+                    }
+                }
+                sum += Math.min(back, n - back);
+            }
+            answer = Math.min(answer, sum);
+        }
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
- **[문제 사이트](https://www.acmicpc.net/problem/1285)** : 
  - [x] 백준
  - [ ] Programmers
  - [ ] SWEA

- **난이도**:
  - Gold 1

- **사용한 알고리즘**
  - Greedy, Bitmasking

- **어려웠던 점**:
  - 완전 탐색인데 그리디를 곁들인 완전 탐색이였다. 모든 열과 행을 다뒤집으면 2^40이라 풀이 방법이 떠오르지 않아서 해답을 봤다. 그래도 이해가 잘 되지 않아 다시 봐야할 것 같다.
  - 포인트는 열과 행을 다뒤집는게 아닌 둘 중 행만 골라서 2^n개만큼 모든 경우를 다 탐색하며 고르지 않은 나머지 열을 기준으로 한개 씩 뒤집고, 동전이 뒷면이면 카운트를 해준다음 앞면과 뒷면중 작은 것을 sum에 더하는 방식으로 완탐과 같은 결과를 낸다. 무슨 말인지 잘...모르겠다...흑흑

- **Reference** :
  - [팽이돌리기 블로그](https://gre-eny.tistory.com/279)

- **etc**:
  - 