### PR TITLE
16437_양 구출 작전

### DIFF
--- a/YOUNGLIN/BOJ_16437_양구출작전.java
+++ b/YOUNGLIN/BOJ_16437_양구출작전.java
@@ -1,0 +1,91 @@
+package day2205.day17;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+/*
+15
+S 100 1
+W 500 1
+W 100 1
+S 1000 2
+W 1000 2
+S 900 6
+W 900 5
+S 600 8
+S 1000 3
+S 100 10
+S 100 11
+S 200 6
+S 100 4
+S 200 4
+
+answer = 2100
+*/
+public class BOJ_16437_양구출작전 {
+
+    static class Node {
+        int vertex;
+        long wc;
+        long sc;
+        Node next;
+
+        public Node(int vertex, long wc, long sc, Node next) {
+            this.vertex = vertex;
+            this.wc = wc;
+            this.sc = sc;
+            this.next = next;
+        }
+    }
+
+    static int N;
+    static Node[] graph;
+    static boolean visited[], isWolf[];
+
+    public static void main(String[] args) throws IOException {
+        input();
+        //1번 노드의 연결되어있는 노드들로부터 최종 생존된 양의 갯수를 받아온다.
+        long sum = dfs(1, 0, 0);
+
+        System.out.println(sum);
+    }
+
+
+    private static long dfs(int now, long wolfCnt, long sheepCnt) {
+        long sum = sheepCnt;
+        //연결된 자식노드의 양의 마리수를 합산해옴
+        for (Node temp = graph[now]; temp != null; temp = temp.next) {
+            long wc = temp.wc;
+            long sc = temp.sc;
+            sum += dfs(temp.vertex, wc, sc);
+        }
+
+        //현재 섬이 늑대섬이면 현재 섬이 가지고있는 늑대 수를 한번만 빼줌
+        if (isWolf[now]) sum -= wolfCnt;
+        sum = sum < 0 ? 0 : sum;
+
+        return sum;
+    }
+
+    private static void input() throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+        graph = new Node[N + 1];
+        visited = new boolean[N + 1];
+        isWolf = new boolean[N + 1];
+        for (int i = 2; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            String t = st.nextToken();
+            long a = Long.parseLong(st.nextToken());
+            int p = Integer.parseInt(st.nextToken());
+            if (t.equals("W")) {
+                isWolf[i] = true;
+                graph[p] = new Node(i, a, 0, graph[p]);
+            } else {
+                graph[p] = new Node(i, 0, a, graph[p]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 아래 양식을 이용해서 문제의 대강을 작성해주세요.

- **문제 사이트** : 
  - [x] 백준
  - [ ] Programmers
  - [ ] SWEA

- **난이도**:
  - Gold 2

- **사용한 알고리즘**
  - dfs

- **어려웠던 점**:
  - 처음에 틀린 이유는 최대 동물의 말리수가 10의9승까지 이기 때문에 long타입 신경을 써주지 않아 틀렸고
  - 두번째 틀린 이유는 단순히 방문하지않은 2~N까지 모든 노드에서 1번까지 양을 데리고 갔기 때문에 중복되는 양의 마릿수가 생겨 틀렸고
  - 세번째 틀린 이유는 1번노드에서 연결된 자식노드 2, 3, 4가 있다면 2, 3, 4에서 연결된 자식노드를 타고 타고 맨 마지막 리프노드의 양갯수를 가져오는 식의 dfs탐색을 통해 양의 마릿수를 계산했으나 현재 노드가 늑대노드일 때는 현재 섬으로 오는 양이 올 때마다 늑대가 잡아먹게 이해를 했었다. 
  - 하지만 늑대는 최대한마리당 한마리만 먹는다고 했기 때문에 전체 양의 마릿수에서 늑대를 한 번만 빼주어야 했다.

- **Reference** :
  - 

- **etc**:
  - 오늘부터 티어와 분류를 보지않고 풀기로 다짐했다. 이번 문제 그냥 풀었떠니 맞았따. 근데 풀고보니 골드2? 쩐다