### PR TITLE
1781_컵라면

### DIFF
--- a/YOUNGLIN/BOJ_1781_컵라면.java
+++ b/YOUNGLIN/BOJ_1781_컵라면.java
@@ -1,0 +1,69 @@
+package day2205.day24;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_1781_컵라면 {
+
+    static class Race implements Comparable<Race> {
+        int pNum, deadline, ramenNum;
+
+        Race(int a, int b, int c) {
+            pNum = a;
+            deadline = b;
+            ramenNum = c;
+        }
+
+        @Override
+        public int compareTo(Race o) {
+            return Integer.compare(this.deadline, o.deadline);
+        }
+    }
+
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+    static int N;
+    static Race[] problems;
+
+    public static void main(String[] args) throws Exception{
+        input();
+        solve();
+    }
+
+    static int pI(String s) { return Integer.parseInt(s);}
+
+    static void input() throws Exception {
+        st = new StringTokenizer(br.readLine());
+        N = pI(st.nextToken());
+        problems = new Race[N];
+
+        for(int i = 0; i < N; i++){
+            st = new StringTokenizer(br.readLine());
+            problems[i] = new Race(i+1, pI(st.nextToken()), pI(st.nextToken()));
+        }
+    }
+
+    static void solve() throws IOException {
+        // 데드라인 기준으로 정렬한다.
+        Arrays.sort(problems);
+
+        PriorityQueue<Integer> pq = new PriorityQueue<Integer>();
+
+        for(int i = 0; i < N;i++){
+            // 현재 데드라인보다 많은 수의 과제를 수행할 수 없다.
+
+            // 작은 것부터 위로오게 한다.
+            pq.add(problems[i].ramenNum);
+            while(pq.size() > problems[i].deadline)
+                pq.poll();
+        }
+
+        int ans = 0;
+        while(!pq.isEmpty())
+            ans += pq.poll();
+
+        System.out.println(ans);
+    }
+}


### PR DESCRIPTION
- **[문제 사이트](https://www.acmicpc.net/problem/1781)** : 
  - [x] 백준
  - [ ] Programmers
  - [ ] SWEA

- **난이도**:
  - Gold 2

- **사용한 알고리즘**
  - Greedy, PriorityQueue

- **어려웠던 점**:
  - 그리디 알고리즘이였는데 방법이 쉽게 떠오르지 않아 결국 해답을 봤다.
  - 데드라인 기준 내림차순 정렬을 한 번 해준 뒤, 순서대로 우선순위 큐에 넣으면서 우선순위큐의 사이즈가 데드라인의 갯수를 넘어가면 컵라면이 작은 순서대로 빼주는게 포인트였다. 2중정렬?인셈

- **Reference** :
  - [블로그](https://for-development.tistory.com/90)

- **etc**:
  - 